### PR TITLE
Add Roblox Graveyard Field map generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ npm run build # emits dist/main.js and copies index.html
 
 Open `game/dist/index.html` in a browser to view the placeholder scene.
 
+To inspect the prototype **Graveyard Field** layout used for the tower-defense level,
+open `game/public/graveyard-preview.html` in a browser. It renders a 500×500 ft
+graveyard map with the winding path and scattered graves so you can visually
+verify the terrain before importing it into Roblox.
+
 ## Infrastructure
 
 The `infra` directory includes stubbed AWS CDK constructs.

--- a/game/public/graveyard-preview.html
+++ b/game/public/graveyard-preview.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Graveyard Field Preview</title>
+    <style>body { margin: 0; }</style>
+  </head>
+  <body>
+    <script type="module">
+      import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+      import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+      const renderer = new THREE.WebGLRenderer({ antialias: true });
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      document.body.appendChild(renderer.domElement);
+
+      // lighting
+      const ambient = new THREE.AmbientLight(0x808080);
+      scene.add(ambient);
+      const dir = new THREE.DirectionalLight(0xffffff, 0.5);
+      dir.position.set(0, 200, 100);
+      scene.add(dir);
+
+      // ground plane 500x500
+      const groundGeom = new THREE.PlaneGeometry(500, 500);
+      const groundMat = new THREE.MeshLambertMaterial({ color: 0x225522 });
+      const ground = new THREE.Mesh(groundGeom, groundMat);
+      ground.rotation.x = -Math.PI / 2;
+      scene.add(ground);
+
+      // path segments
+      const pathPoints = [
+        new THREE.Vector3(50, 0, 450),
+        new THREE.Vector3(100, 0, 300),
+        new THREE.Vector3(200, 0, 200),
+        new THREE.Vector3(300, 0, 300),
+        new THREE.Vector3(400, 0, 150),
+        new THREE.Vector3(450, 0, 50)
+      ];
+      const PATH_WIDTH = 20;
+      for (let i = 0; i < pathPoints.length - 1; i++) {
+        const p1 = pathPoints[i];
+        const p2 = pathPoints[i + 1];
+        const diff = p2.clone().sub(p1);
+        const length = diff.length();
+        const geom = new THREE.BoxGeometry(PATH_WIDTH, 1, length);
+        const mat = new THREE.MeshLambertMaterial({ color: 0x555555 });
+        const segment = new THREE.Mesh(geom, mat);
+        const mid = p1.clone().add(diff.multiplyScalar(0.5));
+        segment.position.copy(mid);
+        const angle = Math.atan2(p2.x - p1.x, p2.z - p1.z);
+        segment.rotation.y = angle;
+        scene.add(segment);
+      }
+
+      // graves scattered around edges
+      function addGrave(x, z) {
+        const baseGeom = new THREE.BoxGeometry(4, 1, 2);
+        const baseMat = new THREE.MeshLambertMaterial({ color: 0x646464 });
+        const base = new THREE.Mesh(baseGeom, baseMat);
+        base.position.set(x, 0, z);
+        scene.add(base);
+
+        const headGeom = new THREE.BoxGeometry(2, 3, 1);
+        const headMat = new THREE.MeshLambertMaterial({ color: 0x828282 });
+        const head = new THREE.Mesh(headGeom, headMat);
+        head.position.set(x, 2, z);
+        scene.add(head);
+      }
+
+      for (let i = 0; i < 60; i++) {
+        const x = Math.random() * 460 + 20;
+        const z = Math.random() * 460 + 20;
+        if (x < 80 || x > 420 || z < 80 || z > 420) {
+          addGrave(x, z);
+        }
+      }
+
+      // camera setup with orbit controls
+      camera.position.set(250, 200, 600);
+      const controls = new OrbitControls(camera, renderer.domElement);
+      controls.target.set(250, 0, 250);
+      controls.update();
+
+      function animate() {
+        requestAnimationFrame(animate);
+        renderer.render(scene, camera);
+      }
+      animate();
+    </script>
+  </body>
+</html>

--- a/game/roblox/GraveyardField.lua
+++ b/game/roblox/GraveyardField.lua
@@ -1,0 +1,80 @@
+-- Graveyard Field map generation for Roblox Tower Defense
+-- Generates a 500x500 stud (approx ft) graveyard-themed play field
+-- Run this in a Roblox Studio command bar or Script to spawn the map
+
+local Terrain = workspace.Terrain
+local Lighting = game:GetService("Lighting")
+
+-- Base ground
+local MAP_SIZE = Vector3.new(500, 1, 500)
+local ground = Instance.new("Part")
+ground.Name = "Ground"
+ground.Size = MAP_SIZE
+ground.Anchored = true
+ground.Material = Enum.Material.Grass
+ground.CFrame = CFrame.new(MAP_SIZE.X/2, -0.5, MAP_SIZE.Z/2)
+ground.Parent = workspace
+
+-- Lighting for spooky atmosphere
+Lighting.Ambient = Color3.fromRGB(80, 80, 80)
+Lighting.FogColor = Color3.fromRGB(60, 60, 60)
+Lighting.FogEnd = 300
+
+-- Path configuration
+local PATH_WIDTH = 20
+local pathPoints = {
+    Vector3.new(50, 0, 450),
+    Vector3.new(100, 0, 300),
+    Vector3.new(200, 0, 200),
+    Vector3.new(300, 0, 300),
+    Vector3.new(400, 0, 150),
+    Vector3.new(450, 0, 50)
+}
+
+-- Build path segments between points
+for i = 1, #pathPoints - 1 do
+    local p1 = pathPoints[i]
+    local p2 = pathPoints[i+1]
+    local diff = p2 - p1
+    local length = diff.Magnitude
+    local segment = Instance.new("Part")
+    segment.Anchored = true
+    segment.Material = Enum.Material.Cobblestone
+    segment.Color = Color3.fromRGB(80, 80, 80)
+    segment.Size = Vector3.new(PATH_WIDTH, 1, length)
+    segment.CFrame = CFrame.new(p1 + diff/2, p2)
+    segment.Parent = workspace
+end
+
+-- Helper to add a grave at a position
+local function addGrave(pos)
+    local base = Instance.new("Part")
+    base.Size = Vector3.new(4, 1, 2)
+    base.Material = Enum.Material.Slate
+    base.Color = Color3.fromRGB(100, 100, 100)
+    base.Anchored = true
+    base.CFrame = CFrame.new(pos)
+    base.Parent = workspace
+
+    local headstone = Instance.new("Part")
+    headstone.Size = Vector3.new(2, 3, 1)
+    headstone.Material = Enum.Material.Concrete
+    headstone.Color = Color3.fromRGB(130, 130, 130)
+    headstone.Anchored = true
+    headstone.CFrame = CFrame.new(pos + Vector3.new(0, 2, 0))
+    headstone.Parent = workspace
+end
+
+-- Scatter graves around outer area, avoid path center
+for i = 1, 60 do
+    local x = math.random(20, 480)
+    local z = math.random(20, 480)
+    if (x < 80 or x > 420) or (z < 80 or z > 420) then
+        addGrave(Vector3.new(x, 0, z))
+    end
+end
+
+return {
+    spawnPoint = pathPoints[1],
+    exitPoint = pathPoints[#pathPoints],
+}


### PR DESCRIPTION
## Summary
- add Graveyard Field Roblox map generation script to create 500x500ft graveyard with path and graves
- add browser-based Three.js preview to visualize Graveyard Field map

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b22f52d5f08322bea4aa639d65800f